### PR TITLE
Change PaymentModel#date type to datetime_utc

### DIFF
--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -59,8 +59,8 @@ module Xeroizer
       guid         :branding_theme_id
       string       :url
       string       :type
-      date         :date
-      date         :due_date
+      datetime_utc :date
+      datetime     :due_date
       string       :status
       string       :line_amount_types
       decimal      :sub_total, :calculated => true

--- a/lib/xeroizer/models/payment.rb
+++ b/lib/xeroizer/models/payment.rb
@@ -13,7 +13,7 @@ module Xeroizer
       set_primary_key :payment_id
 
       guid          :payment_id
-      date          :date
+      datetime_utc  :date
       decimal       :amount
       decimal       :currency_rate
       string        :payment_type


### PR DESCRIPTION
By changing the type of `PaymentModel#date` to `datetime_utc`, we can pass timestamps with UTC offsets to Xero's payments API endpoint, and let Xero parse the dates in the proper timezone for the Organisation in context.
