### PR TITLE
[internal] Removes ssl certificates

### DIFF
--- a/lib/xeroizer/partner_application.rb
+++ b/lib/xeroizer/partner_application.rb
@@ -1,41 +1,36 @@
 module Xeroizer
   class PartnerApplication < GenericApplication
-    
     extend Forwardable
     def_delegators :client, :request_token, :authorize_from_request, :renew_access_token, :expires_at, :authorization_expires_at, :session_handle, :authorize_from_access
-    
+
     public
-    
+
       # Partner applications allow for public AccessToken's received via the stanard OAuth
       # authentication process to be renewed up until the session's expiry. The default session
       # expiry for Xero is 365 days and the default AccessToken expiry is 30 minutes.
-      # 
+      #
       # @param [String] consumer_key consumer key/token from application developer (found at http://api.xero.com for your application).
       # @param [String] consumer_secret consumer secret from application developer (found at http://api.xero.com for your application).
       # @param [String] path_to_private_key application's private key for message signing (uploaded to http://api.xero.com)
-      # @param [String] path_to_ssl_client_cert client-side SSL certificate file to use for requests
-      # @param [String] path_to_ssl_client_key client-side SSL private key to use for requests
       # @param [Hash] options other options to pass to the GenericApplication constructor
       # @return [PartnerApplication] instance of PrivateApplication
-      def initialize(consumer_key, consumer_secret, path_to_private_key, path_to_ssl_client_cert, path_to_ssl_client_key, options = {})
+      def initialize(consumer_key, consumer_secret, path_to_private_key, options = {})
         default_options = {
-          :xero_url         => 'https://api-partner.network.xero.com/api.xro/2.0',
-          :site             => 'https://api-partner.network.xero.com',
-          :authorize_url    => 'https://api.xero.com/oauth/Authorize',      
+          :xero_url         => 'https://api.xero.com/api.xro/2.0',
+          :site             => 'https://api.xero.com',
+          :authorize_url    => 'https://api.xero.com/oauth/Authorize',
           :signature_method => 'RSA-SHA1'
         }
         options = default_options.merge(options).merge(
-          :private_key_file => path_to_private_key,
-          :ssl_client_cert  => OpenSSL::X509::Certificate.new(File.read(path_to_ssl_client_cert)),
-          :ssl_client_key   => OpenSSL::PKey::RSA.new(File.read(path_to_ssl_client_key))
+          :private_key_file => path_to_private_key
         )
         super(consumer_key, consumer_secret, options)
-        
+
         # Load up an existing token if passed the token/key.
         if options[:access_token] && options[:access_key]
           authorize_from_access(options[:access_token], options[:access_key])
         end
-        
+
         # Save the session_handle if passed in so we can renew the token.
         if options[:session_handle]
           client.session_handle = options[:session_handle]


### PR DESCRIPTION
## Description
Updates partner url to use `api.xero.com` and removes Entrust Certificate which is being deprecated April 1, 2017.

https://developer.xero.com/documentation/auth-and-limits/entrust-certificate-deprecation